### PR TITLE
Eclipse Oxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 target/
+/.project

--- a/org.eclipse.lsp4e.php-repository/category.xml
+++ b/org.eclipse.lsp4e.php-repository/category.xml
@@ -6,9 +6,6 @@
    <bundle id="org.eclipse.lsp4e" version="0.0.0">
       <category name="dep"/>
    </bundle>
-   <bundle id="org.eclipse.lsp4e.languages" version="0.0.0">
-      <category name="dep"/>
-   </bundle>
    <bundle id="org.eclipse.lsp4j" version="0.0.0">
       <category name="dep"/>
    </bundle>

--- a/org.eclipse.lsp4e.php/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.php/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.eclipse.lsp4e.php.Activator
 Bundle-Vendor: EclipseLabs.org
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface.text,
- org.eclipse.lsp4e,
+ org.eclipse.lsp4e;bundle-version="0.2.0",
  org.eclipse.ui,
  org.eclipse.ui.genericeditor,
  org.eclipse.tm4e.core,

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tycho-version>0.26.0</tycho-version>
+        <tycho-version>1.0.0</tycho-version>
     </properties>
 
     <repositories>
         <repository>
             <id>neon</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/releases/neon/</url>
+            <url>http://download.eclipse.org/releases/oxygen/</url>
         </repository>
         <repository>
             <id>lsp4e</id>
@@ -25,7 +25,12 @@
         <repository>
             <id>textmate4e</id>
             <layout>p2</layout>
-            <url>http://oss.opensagres.fr/textmate/1.0.0-SNAPSHOT/</url>
+            <url>http://oss.opensagres.fr/textmate/0.1.0-SNAPSHOT/</url>
+        </repository>
+        <repository>
+        		<id>orbit</id>
+        		<layout>p2</layout>
+        		<url>http://download.eclipse.org/tools/orbit/R-builds/R20170307180635/repository</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The current snapshot of lsp4e is version 0.2 and requires Eclipse Oxygen, e.g. Mylyn Wikitext 3.0.

With this PR the project is upgraded to build for Oxygen